### PR TITLE
chore: Bump actions/cache to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   name: Cache Dependencies
-                uses: actions/cache@v1
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
### Summary 🌟
`actions/cache` v1 and v2 are [deprecated](https://github.com/actions/cache/discussions/1510). v3 and v4 are completely backwards compatible and we can just bump the versions. Passing CI is testing this change.